### PR TITLE
Fix some Example code and proof-reading text

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Imports:
     gamlss, 
     nlme, 
     snow,
-    boot
+    boot,
+    coxed
 RoxygenNote: 7.1.2
 Suggests: 
     knitr,

--- a/R/ICTpower.R
+++ b/R/ICTpower.R
@@ -25,11 +25,11 @@
 #' are included if they appear in the data, equivalent to \code{interactions =
 #' list(c("Time", "phase"), c("Time", "group"), c("group", "phase"))}.
 #'
-#' @param B The number of simulated dataset (or parametric bootstrap replications).
+#' @param B The number of simulated datasets (or parametric bootstrap replications).
 #'
-#' @param dataFile Character. A file name for exntant data. Use this option to
+#' @param dataFile Character. A file name for extant data. Use this option to
 #' do a non-parametric bootstrap (e.g., for finite sample power).
-#' If \code{dataFile} is provide, \code{design}
+#' If \code{dataFile} is provided, \code{design}
 #' will be ignored. The \code{dataFile} must be a *.csv file with the variables
 #' 'id' and 'Time', optionally 'phase' and/or 'group', and dependent variables
 #' labeled 'y'. Alternatively, \code{dataFile} may be a *.Rdata file named 'Data'
@@ -85,35 +85,23 @@
 #'
 #' # parametric bootstrap examples
 #'
-#' # lazy cloning - this can lead to errors as `myPolyICT` is updated with each
-#' # call to `myPolyICT$update`
+#' # when updating a designICT object, use safe cloning to avoid errors updating
+#' an object
 #'
-#' #testICTpower10 <- ICTpower(c('testICTpower10', 'csv'),
-#' #  myPolyICT, B=3,
-#' #  seed = 54)
-#' #testICTpower20 <- ICTpower(c('testICTpower20', 'csv'),
-#' #  myPolyICT$update(groups=c(group1=20, group2=20)), B=3,
-#' #  seed = 23)
-#' #testICTpower20t100 <- ICTpower(c('testICTpower20', 'csv'),
-#' #  myPolyICT$update(groups=c(group1=20, group2=20),
-#' #  phases=makePhase(c(20,60,20))),
-#' #  B=3, seed = 24)
-#'
-#' # parametric examples with safe cloning
 #' myPolyICT2 <- myPolyICT$clone(deep=TRUE)
-#' myPolyICT2$update(groups=c(group1=20, group2=20))
+#' myPolyICT2$inputMat$n <- c(group1=20, group2=20)
 #' testICTpower20 <- ICTpower(c('testICTpower20', 'csv'),
 #'   myPolyICT2, B=3, seed = 25, prompt=FALSE)
 #'
 #' myPolyICT3 <- myPolyICT$clone(deep=TRUE)
-#' myPolyICT3$update(groups=c(group1=20, group2=20),
-#'   phases=makePhase(c(20,60,20)))
+#' myPolyICT3$inputMat$n <- c(group1=20, group2=20)
+#' myPolyICT3$inputMat$nObs <- c(20,60,20)
 #' testICTpower20t100 <- ICTpower(c('testICTpower20', 'csv'),
 #'   myPolyICT3, B=3, seed = 26, prompt = FALSE)
 #'
 #' myPolyICT4 <- myPolyICT$clone(deep=TRUE)
-#' myPolyICT4$update(groups=c(group1=20, group2=20),
-#'   phases=makePhase(c(20,60,20)))
+#' myPolyICT4$inputMat$n <- c(group1=20, group2=20)
+#' myPolyICT4$inputMat$nObs <- c(20,60,20)
 #' testICTpower20t100 <- ICTpower(c('testICTpower20', 'csv'),
 #'   myPolyICT4, B=3, seed = 27, prompt = FALSE)
 #'
@@ -122,7 +110,7 @@
 #'
 #' # create a population with 500 participants per group
 #' myPolyICTnonPar <- myPolyICT$clone(deep=TRUE)
-#' myPolyICTnonPar$update(groups=c(group1=500, group2=500))
+#' myPolyICTnonPar$inputMat$n <- c(group1=500, group2=500)
 #' Data <- myPolyICTnonPar$makeData()
 #' save(Data, file = "Data.RData")
 #'
@@ -152,7 +140,7 @@
 #' # Timing run for B=1000
 #' start_time <- Sys.time()
 #' myPolyICT2 <- myPolyICT$clone(deep=TRUE)
-#' myPolyICT2$update(groups=c(group1=20, group2=20))
+#' myPolyICT2$inputMat$n <- c(group1=20, group2=20)
 #' testICTpower20 <- ICTpower(c('testICTpower20', 'csv'),
 #'   myPolyICT2, B=1000, seed = 25, prompt=FALSE)
 #' end_time <- Sys.time()

--- a/R/ICTpowerSim.R
+++ b/R/ICTpowerSim.R
@@ -4,12 +4,12 @@
 #'
 #' @author Stephen Tueller \email{stueller@@rti.org}
 #'
-#' @param designs A named list of designs.
-#' in \code{\link{ICTpower}}. The names in the named list will be passed to
+#' @param designs Named list. Each element in the list is an \code{\link{ICTpower}}
+#' design. The names in the named list will be passed to
 #' the parameter \code{file} in \code{\link{ICTpower}}.
 #'
 #' @param pReportName Character. A name used to create output files. The default
-#' is \code{"ICTpowerSimResults"}
+#' is \code{"ICTpowerSimResults"}.
 #'
 #' @param B Numeric (integer). The number of replicated data sets per \code{design}
 #' in \code{designs}.
@@ -32,9 +32,9 @@
 #' @param dotar Logical. The default is \code{FALSE}. Should the data files
 #' (if requested, see \code{save}) and analysis results be saved in a *.tar
 #' file with the same name as \code{pReportName} and then delete the unzipped
-#' copies of these files? This is suggested wheth the number of designs is
-#' large. The summary of power across all conditions will no be included in the
-#' *.tar archive. It is strongly encourage that a test run with only three
+#' copies of these files? This is suggested when the number of designs is
+#' large. The summary of power across all conditions will not be included in the
+#' *.tar archive. It is strongly encouraged that a test run with only three
 #' designs and B=3 is attempted at first to make sure archiving is done
 #' correctly. If the path names resulting from your working directory are
 #' too long, archiving will fail with the error "storing paths of more than 100
@@ -48,7 +48,7 @@
 #' designs <- list()
 #' designs[["defaultsN20"]] <- polyICT$new()
 #' designs[["defaultsN40"]] <- designs[["defaultsN20"]]$clone(deep=TRUE)
-#' designs[["defaultsN40"]]$update(groups = c(group1=40, group2=40))
+#' designs[["defaultsN40"]]$inputMat$n <- c(group1=40, group2=40)
 #'
 #' # run the simulation (without saving output, console print only)
 #' ICTpowerSim(designs, pReportName  = "ex1", B=3)

--- a/R/designICT.R
+++ b/R/designICT.R
@@ -367,7 +367,7 @@
 #'
 #'   \item{\code{print}}{
 #'
-#'     A method for printing a the primary inputs for an ICT design.
+#'     A method for printing the primary inputs for an ICT design.
 #'
 #'   }
 #'

--- a/R/error.R
+++ b/R/error.R
@@ -257,7 +257,7 @@ Err <- R6::R6Class("err",
 #' # constrained to be in (0,1)
 #' hist(errBeta)
 #' plot(errBeta)
-#' auto.arima(ts(errBeta))
+#' forecast::auto.arima(ts(errBeta))
 armaErr <- R6::R6Class("errARMA",
 
   inherit = Err,

--- a/R/fastDist.R
+++ b/R/fastDist.R
@@ -305,7 +305,6 @@ setupDist <- function(design, err, famParms, propErrVar, file = 'setupDist')
 #'
 #' @examples
 #'
-#' # makePhase example
 #' makePhase()
 makePhase <- function(nObsPerPhase = c(10,20,10) ,
                       phaseNames = NULL  )

--- a/R/polyICT.r
+++ b/R/polyICT.r
@@ -15,7 +15,7 @@
 #' @details
 #' The \code{polyICT} class generator specifies the inputs needed to simulate
 #' data from a polynomial growth model. Once a \code{polyICT} object is created,
-#' you can called its methods and examine or update its fields.
+#' you can call its methods and examine or update its fields.
 #'
 #' Methods are functions that come packaged within your \code{polyICT} object
 #' and include \code{$print()} for printing the inputs,
@@ -24,7 +24,7 @@
 #' \code{$makeData} for simulating a single data set. See the section
 #' titled \strong{Methods}.
 #'
-#' Fields are all the data stored within a \code{polyICT} object,
+#' Fields contain all the data stored within a \code{polyICT} object,
 #' some of which are provided by the user when initializing a \code{polyICT}
 #' object, and others which are derived from these inputs and cannot be changed
 #' by the user directly. These are detailed in the section titled \strong{Fields}.
@@ -143,7 +143,7 @@
 #'   \strong{Methods} section for more details.
 #'
 #'   \code{merror} An error object for the measurement error. The default
-#'   is \code{armaErr$new(list()}, a white noise process. See
+#'   is \code{armaErr$new(list())}, a white noise process. See
 #'   \code{\link{armaErr}}. Also see \code{makeData} in the \strong{Methods}
 #'   section for more details.
 #'
@@ -167,7 +167,7 @@
 #'
 #'   \item{\code{designCheck}}{See \code{\link{designICT}}.}
 #'
-#'   \item{\code{update}}{A method to update editable field in a \code{polyICT}
+#'   \item{\code{update}}{A method to update editable fields in a \code{polyICT}
 #'   object. Fields that can be updated are those listed in \code{new}. New
 #'   values are passed by name using, for example,
 #'   \code{$update(groups=c(group1=25, group2=25), randFxOrder=2)}. The are no
@@ -182,7 +182,7 @@
 #'
 #'     \code{seed} Numeric. The default is \code{123}. A random seed for
 #'     reproducibility. If multiple calls are made to \code{makeData}, the seed
-#'     should change for each call as is done automatically by
+#'     will change for each call as is done automatically by
 #'     \code{\link{ICTpower}}.
 #'   }
 #' }
@@ -205,8 +205,8 @@
 #'   )
 #'
 #' # print the object
-#'
 #' myPolyICT
+#'
 #' # equivalent to:
 #' #print(myPolyICT)
 #' #myPolyICT$print()
@@ -235,6 +235,8 @@
 #' myPolyICT$inputMat
 #'
 #' # now do a large sample (n=5,000/group) check of the design using $designCheck.
+#' #myPolyICT$designCheck(npg = 5000)
+#'
 #' # Notice that in group 2, there is a jump of about .3*15=4.5 between phases
 #' # one and two, and that within phase 3 there is -.6*15=-9 point reduction. This
 #' # is not run when calling example(polyICT) due to it taking several seconds to


### PR DESCRIPTION
Minor edits to the text. 
Fixed some of the examples that were not working. Primarily, the issue was related to the $update function. I replaced $update with direct edits to $inputMat.
See issue #19 for an error that I couldn't figure out. 